### PR TITLE
Add script to enable persistent macOS terminal command logging

### DIFF
--- a/scripts/macos/README.md
+++ b/scripts/macos/README.md
@@ -1,0 +1,44 @@
+# macOS Terminal Command Logging Setup
+
+This folder contains a helper script for macOS (including Apple Silicon machines such as the M3 Pro) that configures the default Terminal app to keep a comprehensive, timestamped log of every command you run. The commands are saved into a dedicated log file so you can review or search them at any time.
+
+## Prerequisites
+
+- macOS with the default `zsh` shell (the default on modern macOS releases).
+- Terminal or iTerm2 — any `zsh`-based environment will work.
+
+## Script overview
+
+`setup-command-log.sh` will:
+
+1. Create the folder `~/.config/fastgpt-terminal/` if it does not exist.
+2. Ensure a host-specific log file such as `command-log-MyMacBookPro.tsv` exists.
+3. Append a guarded configuration block to `~/.zshrc` (creating the file if needed).
+4. Configure `zsh` history to retain 500,000 commands, to append instantly, and to share history between sessions.
+5. Register `preexec` and `precmd` hooks that record each command with start/end timestamps, working directory, and exit status in a tab-separated format.
+
+## Usage
+
+```bash
+/bin/zsh scripts/macos/setup-command-log.sh
+```
+
+Run the script from the root of the repository (or copy it elsewhere before running). After executing the script, restart Terminal or run `source ~/.zshrc` to activate the changes.
+
+All commands will then be logged to:
+
+```
+~/.config/fastgpt-terminal/command-log-$(hostname).tsv
+```
+
+Each log entry looks like this (tab-separated values):
+
+```
+2024-04-16T10:15:33-0400    START   /Users/you/projects    git status
+2024-04-16T10:15:33-0400    END     /Users/you/projects    0   git status
+```
+
+- `START` entries are written immediately before a command runs.
+- `END` entries follow the same command and include the exit status (`0` for success).
+
+You can open the log file in any text editor or use commands like `less`, `rg`, or `grep` to search through your history quickly.

--- a/scripts/macos/setup-command-log.sh
+++ b/scripts/macos/setup-command-log.sh
@@ -1,0 +1,61 @@
+#!/bin/zsh
+set -euo pipefail
+
+CONFIG_DIR="${HOME}/.config/fastgpt-terminal"
+LOG_FILE="${CONFIG_DIR}/command-log-$(hostname).tsv"
+ZSHRC="${HOME}/.zshrc"
+BLOCK_START="# >>> fastgpt-command-log >>>"
+BLOCK_END="# <<< fastgpt-command-log <<<"
+
+mkdir -p "${CONFIG_DIR}"
+touch "${LOG_FILE}"
+
+if [ ! -f "${ZSHRC}" ]; then
+  touch "${ZSHRC}"
+fi
+
+if grep -Fq "${BLOCK_START}" "${ZSHRC}"; then
+  echo "[fastgpt-command-log] Configuration block already present in ${ZSHRC}." >&2
+  echo "[fastgpt-command-log] Commands are being logged to ${LOG_FILE}." >&2
+  exit 0
+fi
+
+cat >> "${ZSHRC}" <<'BLOCK'
+# >>> fastgpt-command-log >>>
+# Configure zsh history so every command is saved and easy to search later.
+export HISTFILE="${HOME}/.config/fastgpt-terminal/zsh_history"
+export HISTSIZE=500000
+export SAVEHIST=500000
+setopt INC_APPEND_HISTORY
+setopt SHARE_HISTORY
+setopt EXTENDED_HISTORY
+setopt HIST_IGNORE_ALL_DUPS
+setopt HIST_REDUCE_BLANKS
+
+FASTGPT_COMMAND_LOG_DIR="${HOME}/.config/fastgpt-terminal"
+FASTGPT_COMMAND_LOG_FILE="${FASTGPT_COMMAND_LOG_DIR}/command-log-$(hostname).tsv"
+mkdir -p "${FASTGPT_COMMAND_LOG_DIR}"
+touch "${FASTGPT_COMMAND_LOG_FILE}"
+
+function _fastgpt_log_preexec() {
+  typeset -g FASTGPT_LAST_COMMAND="$1"
+  typeset -g FASTGPT_LAST_DIRECTORY="$PWD"
+  printf '%s\tSTART\t%s\t%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$PWD" "$1" >> "${FASTGPT_COMMAND_LOG_FILE}"
+}
+
+function _fastgpt_log_precmd() {
+  local status=$?
+  if [[ -n "${FASTGPT_LAST_COMMAND-}" ]]; then
+    printf '%s\tEND\t%s\t%s\t%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "${FASTGPT_LAST_DIRECTORY}" "$status" "${FASTGPT_LAST_COMMAND}" >> "${FASTGPT_COMMAND_LOG_FILE}"
+    unset FASTGPT_LAST_COMMAND FASTGPT_LAST_DIRECTORY
+  fi
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec _fastgpt_log_preexec
+add-zsh-hook precmd _fastgpt_log_precmd
+# <<< fastgpt-command-log <<<
+BLOCK
+
+echo "[fastgpt-command-log] Added persistent command logging to ${ZSHRC}." >&2
+echo "[fastgpt-command-log] Commands will be logged to ${LOG_FILE}." >&2


### PR DESCRIPTION
## Summary
- add a macOS helper script that configures zsh to log commands with timestamps and exit statuses
- document how to run the script and where the log is stored

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116c4315ac8327bd2bb9dfe806a804)